### PR TITLE
Added support for file upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-rest",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Interact with Blackboard Learn REST APIs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi Cliff

First of thanks for the node wrapper to the BlackBoard API, it's very useful as I'm getting into integrating with BlackBoard.

I have a suggestion to add support for uploading files via the route **POST /learn/api/public/v1/uploads**
passing the file down as below:

`this._blackboard.post('uploads', {
        file: file,
        complete: (error, response, body) => {
          //...
        }
      })`

Let me know what you think
Cheers